### PR TITLE
Corrected exception state text for disconnected printer

### DIFF
--- a/octomirror-module.js
+++ b/octomirror-module.js
@@ -182,7 +182,7 @@ Module.register("octomirror-module", {
     updateData: function(data) {
         console.log("Updating OctoPrint Data");
         console.log($("#opState")[0]);
-        $("#opState")[0].textContent = (data.state.text.startsWith("Offline: SerialException")) ? this.translate("OFFLINE") : data.state.text;
+        $("#opState")[0].textContent = (data.state.text.startsWith("Offline (Error: SerialException")) ? this.translate("OFFLINE") : data.state.text;
         var icon = $("#opStateIcon")[0];
         if (data.state.flags.printing) {
             icon.innerHTML = `<i class="fa fa-print" aria-hidden="true" style="color:green;"></i>`;


### PR DESCRIPTION
The OctoPrint offline state text changed with https://github.com/foosel/OctoPrint/commit/55d5df7f14f0d37ea2db2e4146083ca9a7b17db1.

Now the module detects the offline state correct again and does not display the long exception message. 